### PR TITLE
fix(devcontainer): resolve versioning

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
     "name": "ClusterTool Cluster",
-    "image": "tccr.io/tccr/devcontainer:v1.0.4@sha256:6fef9fbad850d685ce349f4b5a1b1b470e6555dd3f858594f126f4b4e0437804",
+    "image": "tccr.io/tccr/devcontainer:latest@sha256:6fef9fbad850d685ce349f4b5a1b1b470e6555dd3f858594f126f4b4e0437804",
     "initializeCommand": "docker pull tccr.io/tccr/devcontainer:v1.0.4",
     "postCreateCommand": {
       "setup": "bash ${containerWorkspaceFolder}/.devcontainer/postCreateCommand.sh"


### PR DESCRIPTION
https://quay.io/repository/tccr/devcontainer?tab=tags shows that last year a version 4.0.1 was pushed, despite more recent updates with a lower v1.0.4, hence renovate trying to "update" to 4.0.1. 

Suggest using "latest" tag instead of specific version, then use hash as proxy for versioning.